### PR TITLE
Fix non-minimal signed integer encoding at power-of-two boundaries — v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.0.1]
+### Fixed
+- Fixed `int_to_bytes()` and `bigint_to_bytes()` encoding signed negative integers at exact power-of-two boundaries (`-128*256**n`, e.g. `-32768`, `-(2**31)`, `-(2**63)`) with a redundant leading `0xff` byte instead of the minimal encoding produced by Python's `clvm` and by `clvm_rs`.  
+  This also affected arithmetic results of the deprecated JavaScript evaluator (`run_program`) for those exact values. Found by differential fuzzing against Python `clvm_tools`.
+- Fixed `int_to_bytes()` producing incorrect bytes for values at or beyond `2**31` (JavaScript's `>>` operates on 32-bit integers). It now delegates to `bigint_to_bytes()`.
+
 ## [4.0.0]
 This version is compatible with [`a5b92bb1b3c2e3865ee54060f5188b5b8fd2d9a4`](https://github.com/Chia-Network/clvm/tree/a5b92bb1b3c2e3865ee54060f5188b5b8fd2d9a4) of [clvm](https://github.com/Chia-Network/clvm)
 ### Breaking Change

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clvm",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "ChiaMineJP <admin@chiamine.jp>",
   "description": "Javascript implementation of chia lisp",
   "license": "MIT",

--- a/src/casts.ts
+++ b/src/casts.ts
@@ -84,47 +84,11 @@ export function int_to_bytes(v: number, option?: Partial<TConvertOption>): Bytes
   if(v > Number.MAX_SAFE_INTEGER || v < Number.MIN_SAFE_INTEGER){
     throw new Error(`The int value is beyond ${v > 0 ? "MAX_SAFE_INTEGER" : "MIN_SAFE_INTEGER"}: ${v}`);
   }
-  if(v === 0){
-    return Bytes.NULL;
-  }
-  
-  const signed = (option && typeof option.signed === "boolean") ? option.signed : false;
-  if(!signed && v < 0){
-    throw new Error("OverflowError: can't convert negative int to unsigned");
-  }
-  
-  let byte_count = 1;
-  const div = signed ? 1 : 0;
-  const b16 = 65536;
-  if(v > 0){
-    let right_hand = (v + 1) * (div + 1);
-    while((b16 ** ((byte_count-1)/2 + 1)) < right_hand){
-      byte_count += 2;
-    }
-    right_hand = (v + 1) * (div + 1);
-    while (2 ** (8 * byte_count) < right_hand) {
-      byte_count++;
-    }
-  }
-  else if(v < 0){
-    let right_hand = (-v + 1) * (div + 1);
-    while((b16 ** ((byte_count-1)/2 + 1)) < right_hand){
-      byte_count += 2;
-    }
-    right_hand = -v * 2;
-    while (2 ** (8 * byte_count) < right_hand) {
-      byte_count++;
-    }
-  }
-  
-  const extraByte = signed && v > 0 && ((v >> ((byte_count-1)*8)) & 0x80) > 0 ? 1 : 0;
-  const u8 = new Uint8Array(byte_count + extraByte);
-  for(let i=0;i<byte_count;i++){
-    const j = extraByte ? i+1 : i;
-    u8[j] = (v >> (byte_count-i-1)*8) & 0xff;
-  }
-  
-  return new Bytes(u8);
+  // Delegate to `bigint_to_bytes`. The previous `number`-based implementation
+  // was incorrect for |v| >= 2**31 (JavaScript's `>>` operates on 32-bit
+  // integers) and produced a redundant leading 0xff byte for negative values
+  // at exact power-of-two boundaries such as -32768.
+  return bigint_to_bytes(BigInt(v), option);
 }
 
 // The reason to use `pow` instead of `**` is that some transpiler automatically converts `**` into `Math.pow`
@@ -193,7 +157,10 @@ export function bigint_to_bytes(v: bigint, option?: Partial<TConvertOption>): By
     }
   }
   else if(v < 0){
-    let right_hand = (-v + BigInt(1)) * (div + BigInt(1));
+    // A signed negative v fits in n bytes iff -v*2 <= 2**(8n).
+    // (-v+1)*2 overestimated by one at exact boundaries like -(2**31),
+    // producing a redundant leading 0xff byte.
+    let right_hand = -v * (div + BigInt(1));
     while(pow(b32, BigInt((byte_count-1)/4 + 1)) < right_hand){
       byte_count += 4;
     }

--- a/tests/_casts_test.ts
+++ b/tests/_casts_test.ts
@@ -195,3 +195,57 @@ test("limbs_for_int", () => {
   expect(limbs_for_int(65536)).toBe(3);
   expect(limbs_for_int(-65536)).toBe(3);
 });
+
+test("minimal signed encoding at power-of-two boundaries", () => {
+  // Expected values generated with Python clvm's `int_to_bytes`.
+  // Before the fix, values like -32768 and -(2**31) were encoded with a
+  // redundant leading 0xff byte (e.g. ff8000 instead of 8000).
+  const cases: Array<[string, string]> = [
+    ["1", "01"],
+    ["-1", "ff"],
+    ["127", "7f"],
+    ["-127", "81"],
+    ["128", "0080"],
+    ["-128", "80"],
+    ["129", "0081"],
+    ["-129", "ff7f"],
+    ["255", "00ff"],
+    ["-255", "ff01"],
+    ["256", "0100"],
+    ["-256", "ff00"],
+    ["32767", "7fff"],
+    ["-32767", "8001"],
+    ["32768", "008000"],
+    ["-32768", "8000"],
+    ["32769", "008001"],
+    ["-32769", "ff7fff"],
+    ["8388607", "7fffff"],
+    ["-8388608", "800000"],
+    ["8388608", "00800000"],
+    ["-8388609", "ff7fffff"],
+    ["2147483647", "7fffffff"],
+    ["-2147483648", "80000000"],
+    ["2147483648", "0080000000"],
+    ["-2147483649", "ff7fffffff"],
+    ["140737488355327", "7fffffffffff"],
+    ["-140737488355328", "800000000000"],
+    ["140737488355328", "00800000000000"],
+    ["9223372036854775807", "7fffffffffffffff"],
+    ["-9223372036854775808", "8000000000000000"],
+    ["9223372036854775808", "008000000000000000"],
+    ["-9223372036854775809", "ff7fffffffffffffff"],
+  ];
+  for(const [decimal, hex] of cases){
+    const b = BigInt(decimal);
+    expect(bigint_to_bytes(b, {signed: true}).hex()).toBe(hex);
+    // round trip
+    expect(bigint_from_bytes(h(`0x${hex}`), {signed: true})).toBe(b);
+    const n = Number(decimal);
+    if(Number.isSafeInteger(n)){
+      expect(int_to_bytes(n, {signed: true}).hex()).toBe(hex);
+      if(hex.length * 4 <= 52){
+        expect(int_from_bytes(h(`0x${hex}`), {signed: true})).toBe(n);
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Differential fuzzing of clvm_tools-js against Python clvm_tools (5000 random CLVM programs, `brun -c` output compared byte-for-byte) surfaced two long-standing bugs in `src/casts.ts`:

1. **Non-minimal negative encodings at power-of-two boundaries.** `int_to_bytes`/`bigint_to_bytes` encoded signed negatives of the form `-128·256ⁿ` (`-32768`, `-(2³¹)`, `-(2⁶³)`, …) with a redundant leading `0xff` byte — `ff8000` where Python clvm and clvm_rs produce `8000`. Root cause: the coarse byte-count loop bounds with `(-v+1)*2`, but a signed negative `v` fits `n` bytes iff `-v*2 ≤ 2^(8n)`; the `+1` overshoots exactly at the boundary. Verified present in clvm 1.0.9, so this predates 4.0.0 by years. Consensus-relevant: the JS evaluator's arithmetic results for these exact values serialize differently than clvm_rs.
2. **`int_to_bytes` broken for `|v| ≥ 2³¹`.** The encoding loops use JS `>>`, which operates on 32-bit integers (e.g. `2⁴⁷−1` → `00ffffffffffff` instead of `7fffffffffff`). `int_to_bytes` now validates the safe-integer range and delegates to `bigint_to_bytes`.

## Testing

- New regression table of 33 boundary encodings generated with Python clvm's `int_to_bytes`, exercising both functions plus `*_from_bytes` round-trips — fails on the old code at 8 entries, passes now.
- Full suite: 12 suites, 104 tests, all pass; build succeeds.
- Re-running the 5000-case differential fuzz with this fix applied is in progress in clvm_tools-js (PR Chia-Mine/clvm_tools-js#18).

Version set to 4.0.1.