### PR TITLE
Upgrade bundled clvm_wasm to 0.16.2 — v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.1.0]
+### Changed
+- Upgraded bundled `clvm_wasm` from `0.7.0` to `0.16.2` (the latest wasm build published from [clvm_rs](https://github.com/Chia-Network/clvm_rs)), picking up about two years of `clvm_rs` runtime updates for the `run_chia_program`/`run_clvm` backend
+  - **Behavior change**: `div` with negative operands is now allowed and computes floor division, matching current `clvm_rs` consensus behaviour (verified against `clvm_rs` 0.18.0). `clvm_wasm` 0.7.0 still raised `div operator with negative operands is deprecated`, which is pre-hard-fork behaviour. Note that the deprecated JavaScript evaluator (`run_program`) and Python's `clvm` still reject negative operands
+  - `src/__clvm_wasm__.ts` regenerated for the new wasm-bindgen ABI (externref table instead of the JS heap)
+  - Error strings thrown by `run_chia_program` changed format (e.g. `Raise(NodePtr(SmallAtom, 1337))` instead of `EvalErr(NodePtr(...), "clvm raise")`). They remain opaque strings; do not parse them
+
 ## [4.0.1]
 ### Fixed
 - Fixed `int_to_bytes()` and `bigint_to_bytes()` encoding signed negative integers at exact power-of-two boundaries (`-128*256**n`, e.g. `-32768`, `-(2**31)`, `-(2**63)`) with a redundant leading `0xff` byte instead of the minimal encoding produced by Python's `clvm` and by `clvm_rs`.  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clvm",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "author": "ChiaMineJP <admin@chiamine.jp>",
   "description": "Javascript implementation of chia lisp",
   "license": "MIT",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "bls-signatures": "2.0.3",
-    "clvm_wasm": "0.7.0",
+    "clvm_wasm": "0.16.2",
     "jscrypto": "1.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: 2.0.3
         version: 2.0.3
       clvm_wasm:
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: 0.16.2
+        version: 0.16.2
       jscrypto:
         specifier: 1.0.3
         version: 1.0.3
@@ -862,8 +862,8 @@ packages:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
 
-  clvm_wasm@0.7.0:
-    resolution: {integrity: sha512-JsGOuZEjA1DS2rNtCNL+4PbXWXvvE5nBpHCfg9pe2KVh+IUwUl3xTer4pk++jj+3CIaML9BvnvFowL117E8PSw==}
+  clvm_wasm@0.16.2:
+    resolution: {integrity: sha512-UNfgrXnPwXCrmHHLvQZM47CO62MeNEZTv7N7ZTtptOqHsmo6YQHHf8B6nvGkIlqq4BcyIXAZ8kVS+aq5MwYvTw==}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -3578,7 +3578,7 @@ snapshots:
       kind-of: 6.0.3
       shallow-clone: 3.0.1
 
-  clvm_wasm@0.7.0: {}
+  clvm_wasm@0.16.2: {}
 
   co@4.6.0: {}
 

--- a/src/__clvm_wasm__.ts
+++ b/src/__clvm_wasm__.ts
@@ -4,41 +4,46 @@
  *   1.1. git clone https://github.com/Chia-Network/clvm_rs
  *   1.2. cd clvm_rs/wasm
  *   1.3. cargo install wasm-pack
- *   1.4. wasm-pack build --release --target=bundler
+ *   1.4. wasm-pack build --release --target=nodejs
+ *      (or use the published `clvm_wasm` npm package, whose `clvm_wasm.js` is that output)
  * 2. Preserve loader code embedded below.
- * 3. Check contents of ./pkg/clvm_wasm_bg.wasm.d.ts and compose `ClvmWasmExports` type from it.
- * 3. Copy contents of ./pkg/clvm_wasm_bg.js and paste here
- * 4. Annotate typings, fix lint issues
- * 5. Paste loader code preserved in the previous procedure
- * 6. Add `__wb*` functions to the `imports` object.
- * 7. Add `toJSON()` method to `LazyNode`.
+ * 3. Check functions referenced on `wasm.` in ./pkg/clvm_wasm.js and compose `ClvmWasmExports` type from them.
+ * 4. Copy contents of ./pkg/clvm_wasm.js and paste here
+ * 5. Annotate typings, fix lint issues
+ * 6. Paste loader code preserved in the previous procedure, and make sure
+ *    `wasm.__wbindgen_start()` is called right after instantiation.
+ * 7. Add all `__wbg*`/`__wbindgen*` import functions to `imports["__wbindgen_placeholder__"]`.
+ * 8. Add `toJSON()` method to `LazyNode`.
  */
 import {Word32Array} from "jscrypto/Word32Array";
 
 type ClvmWasmExports = {
   memory: WebAssembly.Memory;
-  serialized_length(a: number, b: number, c: number): void;
-  node_from_bytes(a: number, b: number, c: number, d: number): void;
-  __wbg_flag_free(a: number): void;
+  run_clvm(a: number, b: number, c: number, d: number, e: number): [number, number];
+  run_chia_program(a: number, b: number, c: number, d: number, e: bigint, f: number): [number, number, number];
+  serialized_length(a: number, b: number): [bigint, number, number];
+  node_from_bytes(a: number, b: number, c: number): [number, number, number];
+  __wbg_flag_free(a: number, b: number): void;
   flag_no_unknown_ops(): number;
   flag_allow_backrefs(): number;
-  run_clvm(a: number, b: number, c: number, d: number, e: number, f: number): void;
-  run_chia_program(a: number, b: number, c: number, d: number, e: number, f: bigint, g: number): void;
-  __wbg_lazynode_free(a: number): void;
-  lazynode_pair(a: number): number;
-  lazynode_atom(a: number, b: number): void;
-  lazynode_to_bytes_with_backref(a: number, b: number): void;
-  lazynode_to_bytes(a: number, b: number, c: number): void;
-  lazynode_from_bytes_with_backref(a: number, b: number, c: number): void;
-  lazynode_from_bytes(a: number, b: number, c: number): void;
-  __wbindgen_add_to_stack_pointer(a: number): number;
+  __wbg_lazynode_free(a: number, b: number): void;
+  lazynode_pair(a: number): unknown;
+  lazynode_atom(a: number): [number, number];
+  lazynode_to_bytes_with_backref(a: number): [number, number, number, number];
+  lazynode_to_bytes(a: number, b: number): [number, number, number, number];
+  lazynode_from_bytes_with_backref(a: number, b: number): [number, number, number];
+  lazynode_from_bytes(a: number, b: number): [number, number, number];
+  __wbindgen_export_2: WebAssembly.Table;
+  __externref_table_alloc(): number;
+  __externref_table_dealloc(a: number): void;
+  __wbindgen_exn_store(a: number): void;
   __wbindgen_malloc(a: number, b: number): number;
-  __wbindgen_free(a: number, b: number, c?: number): void;
+  __wbindgen_free(a: number, b: number, c: number): void;
+  __wbindgen_start(): void;
 }
 
 const imports: WebAssembly.Imports = {};
 let wasm: ClvmWasmExports;
-
 
 const lTextDecoder = typeof TextDecoder === "undefined" ? (0, module.require)("util").TextDecoder : TextDecoder;
 
@@ -46,126 +51,58 @@ const cachedTextDecoder = new lTextDecoder("utf-8", {ignoreBOM: true, fatal: tru
 
 cachedTextDecoder.decode();
 
-let cachedUint8Memory0: Uint8Array|null = null;
+function addToExternrefTable0(obj: unknown) {
+  const idx = wasm.__externref_table_alloc();
+  wasm.__wbindgen_export_2.set(idx, obj);
+  return idx;
+}
 
-function getUint8Memory0() {
-  if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
-    cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+// eslint-disable-next-line @typescript-eslint/ban-types
+function handleError(this: unknown, f: Function, args: IArguments) {
+  try {
+    return f.apply(this, args);
+  } catch (e) {
+    const idx = addToExternrefTable0(e);
+    wasm.__wbindgen_exn_store(idx);
   }
-  return cachedUint8Memory0;
+}
+
+function takeFromExternrefTable0(idx: number) {
+  const value = wasm.__wbindgen_export_2.get(idx);
+  wasm.__externref_table_dealloc(idx);
+  return value;
+}
+
+let cachedUint8ArrayMemory0: Uint8Array|null = null;
+
+function getUint8ArrayMemory0() {
+  if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+    cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+  }
+  return cachedUint8ArrayMemory0;
 }
 
 function getStringFromWasm0(ptr: number, len: number) {
   ptr = ptr >>> 0;
-  return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+  return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
-const heap = new Array(128).fill(undefined);
-
-heap.push(undefined, null, true, false);
-
-let heap_next = heap.length;
-
-function addHeapObject(obj: any) {
-  if (heap_next === heap.length) heap.push(heap.length + 1);
-  const idx = heap_next;
-  heap_next = heap[idx];
-  
-  heap[idx] = obj;
-  return idx;
+function isLikeNone(x: unknown) {
+  return x === undefined || x === null;
 }
 
 let WASM_VECTOR_LEN = 0;
 
 function passArray8ToWasm0(arg: Uint8Array, malloc: (size: number, align: number) => number) {
   const ptr = malloc(arg.length * 1, 1) >>> 0;
-  getUint8Memory0().set(arg, ptr / 1);
+  getUint8ArrayMemory0().set(arg, ptr / 1);
   WASM_VECTOR_LEN = arg.length;
   return ptr;
 }
 
-let cachedBigInt64Memory0: BigInt64Array|null = null;
-
-function getBigInt64Memory0() {
-  if (cachedBigInt64Memory0 === null || cachedBigInt64Memory0.byteLength === 0) {
-    cachedBigInt64Memory0 = new BigInt64Array(wasm.memory.buffer);
-  }
-  return cachedBigInt64Memory0;
-}
-
-let cachedInt32Memory0: Int32Array|null = null;
-
-function getInt32Memory0() {
-  if (cachedInt32Memory0 === null || cachedInt32Memory0.byteLength === 0) {
-    cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
-  }
-  return cachedInt32Memory0;
-}
-
-function getObject(idx: number) {
-  return heap[idx];
-}
-
-function dropObject(idx: number) {
-  if (idx < 132) return;
-  heap[idx] = heap_next;
-  heap_next = idx;
-}
-
-function takeObject(idx: number) {
-  const ret = getObject(idx);
-  dropObject(idx);
-  return ret;
-}
-
-/**
- * @param {Uint8Array} program
- * @returns {bigint}
- */
-export function serialized_length(program: Uint8Array): bigint {
-  try {
-    const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-    const ptr0 = passArray8ToWasm0(program, wasm.__wbindgen_malloc);
-    const len0 = WASM_VECTOR_LEN;
-    wasm.serialized_length(retptr, ptr0, len0);
-    const r0 = getBigInt64Memory0()[retptr / 8 + 0];
-    const r2 = getInt32Memory0()[retptr / 4 + 2];
-    const r3 = getInt32Memory0()[retptr / 4 + 3];
-    if (r3) {
-      throw takeObject(r2);
-    }
-    return BigInt.asUintN(64, r0);
-  } finally {
-    wasm.__wbindgen_add_to_stack_pointer(16);
-  }
-}
-
-/**
- * @param {Uint8Array} b
- * @param {number} flag
- * @returns {LazyNode}
- */
-export function node_from_bytes(b: Uint8Array, flag: number): LazyNode {
-  try {
-    const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-    const ptr0 = passArray8ToWasm0(b, wasm.__wbindgen_malloc);
-    const len0 = WASM_VECTOR_LEN;
-    wasm.node_from_bytes(retptr, ptr0, len0, flag);
-    const r0 = getInt32Memory0()[retptr / 4 + 0];
-    const r1 = getInt32Memory0()[retptr / 4 + 1];
-    const r2 = getInt32Memory0()[retptr / 4 + 2];
-    if (r2) {
-      throw takeObject(r1);
-    }
-    return LazyNode.__wrap(r0);
-  } finally {
-    wasm.__wbindgen_add_to_stack_pointer(16);
-  }
-}
-
 function getArrayU8FromWasm0(ptr: number, len: number) {
   ptr = ptr >>> 0;
-  return getUint8Memory0().subarray(ptr / 1, ptr / 1 + len);
+  return getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
 }
 
 /**
@@ -175,21 +112,14 @@ function getArrayU8FromWasm0(ptr: number, len: number) {
  * @returns {Uint8Array}
  */
 export function run_clvm(program: Uint8Array, args: Uint8Array, flag: number): Uint8Array {
-  try {
-    const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-    const ptr0 = passArray8ToWasm0(program, wasm.__wbindgen_malloc);
-    const len0 = WASM_VECTOR_LEN;
-    const ptr1 = passArray8ToWasm0(args, wasm.__wbindgen_malloc);
-    const len1 = WASM_VECTOR_LEN;
-    wasm.run_clvm(retptr, ptr0, len0, ptr1, len1, flag);
-    const r0 = getInt32Memory0()[retptr / 4 + 0];
-    const r1 = getInt32Memory0()[retptr / 4 + 1];
-    const v3 = getArrayU8FromWasm0(r0, r1).slice();
-    wasm.__wbindgen_free(r0, r1 * 1);
-    return v3;
-  } finally {
-    wasm.__wbindgen_add_to_stack_pointer(16);
-  }
+  const ptr0 = passArray8ToWasm0(program, wasm.__wbindgen_malloc);
+  const len0 = WASM_VECTOR_LEN;
+  const ptr1 = passArray8ToWasm0(args, wasm.__wbindgen_malloc);
+  const len1 = WASM_VECTOR_LEN;
+  const ret = wasm.run_clvm(ptr0, len0, ptr1, len1, flag);
+  const v3 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+  wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+  return v3;
 }
 
 /**
@@ -197,7 +127,7 @@ export function run_clvm(program: Uint8Array, args: Uint8Array, flag: number): U
  * @param {Uint8Array} args
  * @param {bigint} max_cost
  * @param {number} flag
- * @returns {[bigint, any]}
+ * @returns {[bigint, LazyNode]}
  */
 export function run_chia_program(
   program: Uint8Array,
@@ -205,42 +135,67 @@ export function run_chia_program(
   max_cost: bigint,
   flag: number,
 ): [bigint, LazyNode] {
-  try {
-    const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-    const ptr0 = passArray8ToWasm0(program, wasm.__wbindgen_malloc);
-    const len0 = WASM_VECTOR_LEN;
-    const ptr1 = passArray8ToWasm0(args, wasm.__wbindgen_malloc);
-    const len1 = WASM_VECTOR_LEN;
-    wasm.run_chia_program(retptr, ptr0, len0, ptr1, len1, max_cost, flag);
-    const r0 = getInt32Memory0()[retptr / 4 + 0];
-    const r1 = getInt32Memory0()[retptr / 4 + 1];
-    const r2 = getInt32Memory0()[retptr / 4 + 2];
-    if (r2) {
-      throw takeObject(r1);
-    }
-    return takeObject(r0);
-  } finally {
-    wasm.__wbindgen_add_to_stack_pointer(16);
+  const ptr0 = passArray8ToWasm0(program, wasm.__wbindgen_malloc);
+  const len0 = WASM_VECTOR_LEN;
+  const ptr1 = passArray8ToWasm0(args, wasm.__wbindgen_malloc);
+  const len1 = WASM_VECTOR_LEN;
+  const ret = wasm.run_chia_program(ptr0, len0, ptr1, len1, max_cost, flag);
+  if (ret[2]) {
+    throw takeFromExternrefTable0(ret[1]);
   }
+  return takeFromExternrefTable0(ret[0]) as [bigint, LazyNode];
 }
+
+/**
+ * @param {Uint8Array} program
+ * @returns {bigint}
+ */
+export function serialized_length(program: Uint8Array): bigint {
+  const ptr0 = passArray8ToWasm0(program, wasm.__wbindgen_malloc);
+  const len0 = WASM_VECTOR_LEN;
+  const ret = wasm.serialized_length(ptr0, len0);
+  if (ret[2]) {
+    throw takeFromExternrefTable0(ret[1]);
+  }
+  return BigInt.asUintN(64, ret[0]);
+}
+
+/**
+ * @param {Uint8Array} b
+ * @param {number} flag
+ * @returns {LazyNode}
+ */
+export function node_from_bytes(b: Uint8Array, flag: number): LazyNode {
+  const ptr0 = passArray8ToWasm0(b, wasm.__wbindgen_malloc);
+  const len0 = WASM_VECTOR_LEN;
+  const ret = wasm.node_from_bytes(ptr0, len0, flag);
+  if (ret[2]) {
+    throw takeFromExternrefTable0(ret[1]);
+  }
+  return LazyNode.__wrap(ret[0]);
+}
+
+const FlagFinalization = (typeof FinalizationRegistry === "undefined")
+  ? {register: () => undefined, unregister: () => undefined}
+  : new FinalizationRegistry((ptr: number) => wasm.__wbg_flag_free(ptr >>> 0, 1));
 
 /**
  */
 export class Flag {
   __wbg_ptr = 0;
-  
+
   __destroy_into_raw() {
     const ptr = this.__wbg_ptr;
     this.__wbg_ptr = 0;
-    
+    FlagFinalization.unregister(this);
     return ptr;
   }
-  
+
   free() {
     const ptr = this.__destroy_into_raw();
-    wasm.__wbg_flag_free(ptr);
+    wasm.__wbg_flag_free(ptr, 0);
   }
-  
+
   /**
    * @returns {number}
    */
@@ -248,7 +203,7 @@ export class Flag {
     const ret = wasm.flag_no_unknown_ops();
     return ret >>> 0;
   }
-  
+
   /**
    * @returns {number}
    */
@@ -258,148 +213,111 @@ export class Flag {
   }
 }
 
+const LazyNodeFinalization = (typeof FinalizationRegistry === "undefined")
+  ? {register: () => undefined, unregister: () => undefined}
+  : new FinalizationRegistry((ptr: number) => wasm.__wbg_lazynode_free(ptr >>> 0, 1));
+
 /**
  */
 export class LazyNode {
   __wbg_ptr = 0;
-  
+
   static __wrap(ptr: number) {
     ptr = ptr >>> 0;
-    const obj = Object.create(LazyNode.prototype);
+    const obj = Object.create(LazyNode.prototype) as LazyNode;
     obj.__wbg_ptr = ptr;
-    
+    LazyNodeFinalization.register(obj, obj.__wbg_ptr, obj);
     return obj;
   }
-  
+
   __destroy_into_raw() {
     const ptr = this.__wbg_ptr;
     this.__wbg_ptr = 0;
-    
+    LazyNodeFinalization.unregister(this);
     return ptr;
   }
-  
+
   free() {
     const ptr = this.__destroy_into_raw();
-    wasm.__wbg_lazynode_free(ptr);
+    wasm.__wbg_lazynode_free(ptr, 0);
   }
-  
+
   /**
-   * @returns {Array<any> | undefined}
+   * @returns {[LazyNode, LazyNode] | undefined}
    */
   get pair(): [LazyNode, LazyNode] | undefined {
     const ret = wasm.lazynode_pair(this.__wbg_ptr);
-    return takeObject(ret);
+    return ret as [LazyNode, LazyNode] | undefined;
   }
-  
+
   /**
    * @returns {Uint8Array | undefined}
    */
   get atom(): Uint8Array | undefined {
-    try {
-      const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-      wasm.lazynode_atom(retptr, this.__wbg_ptr);
-      const r0 = getInt32Memory0()[retptr / 4 + 0];
-      const r1 = getInt32Memory0()[retptr / 4 + 1];
-      let v1;
-      if (r0 !== 0) {
-        v1 = getArrayU8FromWasm0(r0, r1).slice();
-        wasm.__wbindgen_free(r0, r1 * 1);
-      }
-      return v1;
-    } finally {
-      wasm.__wbindgen_add_to_stack_pointer(16);
+    const ret = wasm.lazynode_atom(this.__wbg_ptr);
+    let v1;
+    if (ret[0] !== 0) {
+      v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+      wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
     }
+    return v1;
   }
-  
+
   /**
    * @returns {Uint8Array}
    */
   to_bytes_with_backref(): Uint8Array {
-    try {
-      const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-      wasm.lazynode_to_bytes_with_backref(retptr, this.__wbg_ptr);
-      const r0 = getInt32Memory0()[retptr / 4 + 0];
-      const r1 = getInt32Memory0()[retptr / 4 + 1];
-      const r2 = getInt32Memory0()[retptr / 4 + 2];
-      const r3 = getInt32Memory0()[retptr / 4 + 3];
-      if (r3) {
-        throw takeObject(r2);
-      }
-      const v1 = getArrayU8FromWasm0(r0, r1).slice();
-      wasm.__wbindgen_free(r0, r1 * 1);
-      return v1;
-    } finally {
-      wasm.__wbindgen_add_to_stack_pointer(16);
+    const ret = wasm.lazynode_to_bytes_with_backref(this.__wbg_ptr);
+    if (ret[3]) {
+      throw takeFromExternrefTable0(ret[2]);
     }
+    const v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v1;
   }
-  
+
   /**
    * @param {number} limit
    * @returns {Uint8Array}
    */
   to_bytes(limit: number): Uint8Array {
-    try {
-      const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-      wasm.lazynode_to_bytes(retptr, this.__wbg_ptr, limit);
-      const r0 = getInt32Memory0()[retptr / 4 + 0];
-      const r1 = getInt32Memory0()[retptr / 4 + 1];
-      const r2 = getInt32Memory0()[retptr / 4 + 2];
-      const r3 = getInt32Memory0()[retptr / 4 + 3];
-      if (r3) {
-        throw takeObject(r2);
-      }
-      const v1 = getArrayU8FromWasm0(r0, r1).slice();
-      wasm.__wbindgen_free(r0, r1 * 1);
-      return v1;
-    } finally {
-      wasm.__wbindgen_add_to_stack_pointer(16);
+    const ret = wasm.lazynode_to_bytes(this.__wbg_ptr, limit);
+    if (ret[3]) {
+      throw takeFromExternrefTable0(ret[2]);
     }
+    const v1 = getArrayU8FromWasm0(ret[0], ret[1]).slice();
+    wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+    return v1;
   }
-  
+
   /**
    * @param {Uint8Array} b
    * @returns {LazyNode}
    */
   static from_bytes_with_backref(b: Uint8Array): LazyNode {
-    try {
-      const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-      const ptr0 = passArray8ToWasm0(b, wasm.__wbindgen_malloc);
-      const len0 = WASM_VECTOR_LEN;
-      wasm.lazynode_from_bytes_with_backref(retptr, ptr0, len0);
-      const r0 = getInt32Memory0()[retptr / 4 + 0];
-      const r1 = getInt32Memory0()[retptr / 4 + 1];
-      const r2 = getInt32Memory0()[retptr / 4 + 2];
-      if (r2) {
-        throw takeObject(r1);
-      }
-      return LazyNode.__wrap(r0);
-    } finally {
-      wasm.__wbindgen_add_to_stack_pointer(16);
+    const ptr0 = passArray8ToWasm0(b, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.lazynode_from_bytes_with_backref(ptr0, len0);
+    if (ret[2]) {
+      throw takeFromExternrefTable0(ret[1]);
     }
+    return LazyNode.__wrap(ret[0]);
   }
-  
+
   /**
    * @param {Uint8Array} b
    * @returns {LazyNode}
    */
   static from_bytes(b: Uint8Array): LazyNode {
-    try {
-      const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-      const ptr0 = passArray8ToWasm0(b, wasm.__wbindgen_malloc);
-      const len0 = WASM_VECTOR_LEN;
-      wasm.lazynode_from_bytes(retptr, ptr0, len0);
-      const r0 = getInt32Memory0()[retptr / 4 + 0];
-      const r1 = getInt32Memory0()[retptr / 4 + 1];
-      const r2 = getInt32Memory0()[retptr / 4 + 2];
-      if (r2) {
-        throw takeObject(r1);
-      }
-      return LazyNode.__wrap(r0);
-    } finally {
-      wasm.__wbindgen_add_to_stack_pointer(16);
+    const ptr0 = passArray8ToWasm0(b, wasm.__wbindgen_malloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.lazynode_from_bytes(ptr0, len0);
+    if (ret[2]) {
+      throw takeFromExternrefTable0(ret[1]);
     }
+    return LazyNode.__wrap(ret[0]);
   }
-  
+
   toJSON() {
     if(this.pair){
       return this.pair;
@@ -411,43 +329,127 @@ export class LazyNode {
   }
 }
 
-export function __wbg_lazynode_new(arg0: number) {
-  const ret = LazyNode.__wrap(arg0);
-  return addHeapObject(ret);
-}
-
-export function __wbindgen_string_new(arg0: number, arg1: number) {
-  const ret = getStringFromWasm0(arg0, arg1);
-  return addHeapObject(ret);
-}
-
-export function __wbindgen_bigint_from_u64(arg0: bigint) {
-  const ret = BigInt.asUintN(64, arg0);
-  return addHeapObject(ret);
-}
-
-export function __wbg_newwithlength_3ec098a360da1909(arg0: number) {
-  const ret = new Array(arg0 >>> 0);
-  return addHeapObject(ret);
-}
-
-export function __wbg_set_502d29070ea18557(arg0: number, arg1: number, arg2: number) {
-  getObject(arg0)[arg1 >>> 0] = takeObject(arg2);
-}
-
-export function __wbindgen_throw(arg0: number, arg1: number) {
-  throw new Error(getStringFromWasm0(arg0, arg1));
-}
-
-
 // Loader part
 imports["__wbindgen_placeholder__"] = {
-  __wbg_lazynode_new,
-  __wbindgen_string_new,
-  __wbindgen_bigint_from_u64,
-  __wbg_newwithlength_3ec098a360da1909,
-  __wbg_set_502d29070ea18557,
-  __wbindgen_throw,
+  __wbg_buffer_609cc3eee51ed158: function(arg0: any) {
+    return arg0.buffer;
+  },
+  __wbg_call_672a4d21634d4a24: function(this: unknown, arg0: any, arg1: any) {
+    return handleError(function(arg0: any, arg1: any) {
+      return arg0.call(arg1);
+    }, arguments);
+  },
+  __wbg_call_7cccdd69e0791ae2: function(this: unknown, arg0: any, arg1: any, arg2: any) {
+    return handleError(function(arg0: any, arg1: any, arg2: any) {
+      return arg0.call(arg1, arg2);
+    }, arguments);
+  },
+  __wbg_crypto_ed58b8e10a292839: function(arg0: any) {
+    return arg0.crypto;
+  },
+  __wbg_getRandomValues_bcb4912f16000dc4: function(this: unknown, arg0: any, arg1: any) {
+    return handleError(function(arg0: any, arg1: any) {
+      arg0.getRandomValues(arg1);
+    }, arguments);
+  },
+  __wbg_lazynode_new: function(arg0: number) {
+    return LazyNode.__wrap(arg0);
+  },
+  __wbg_msCrypto_0a36e2ec3a343d26: function(arg0: any) {
+    return arg0.msCrypto;
+  },
+  __wbg_new_a12002a7f91c75be: function(arg0: any) {
+    return new Uint8Array(arg0);
+  },
+  __wbg_newnoargs_105ed471475aaf50: function(arg0: number, arg1: number) {
+    return new Function(getStringFromWasm0(arg0, arg1));
+  },
+  __wbg_newwithbyteoffsetandlength_d97e637ebe145a9a: function(arg0: any, arg1: number, arg2: number) {
+    return new Uint8Array(arg0, arg1 >>> 0, arg2 >>> 0);
+  },
+  __wbg_newwithlength_a381634e90c276d4: function(arg0: number) {
+    return new Uint8Array(arg0 >>> 0);
+  },
+  __wbg_newwithlength_c4c419ef0bc8a1f8: function(arg0: number) {
+    return new Array(arg0 >>> 0);
+  },
+  __wbg_node_02999533c4ea02e3: function(arg0: any) {
+    return arg0.node;
+  },
+  __wbg_process_5c1d670bc53614b8: function(arg0: any) {
+    return arg0.process;
+  },
+  __wbg_randomFillSync_ab2cfe79ebbf2740: function(this: unknown, arg0: any, arg1: any) {
+    return handleError(function(arg0: any, arg1: any) {
+      arg0.randomFillSync(arg1);
+    }, arguments);
+  },
+  __wbg_require_79b1e9274cde3c87: function(this: unknown) {
+    return handleError(function() {
+      return module.require;
+    }, arguments);
+  },
+  __wbg_set_37837023f3d740e8: function(arg0: any, arg1: number, arg2: any) {
+    arg0[arg1 >>> 0] = arg2;
+  },
+  __wbg_set_65595bdd868b3009: function(arg0: any, arg1: any, arg2: number) {
+    arg0.set(arg1, arg2 >>> 0);
+  },
+  __wbg_static_accessor_GLOBAL_88a902d13a557d07: function() {
+    const ret = typeof global === "undefined" ? null : global;
+    return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+  },
+  __wbg_static_accessor_GLOBAL_THIS_56578be7e9f832b0: function() {
+    const ret = typeof globalThis === "undefined" ? null : globalThis;
+    return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+  },
+  __wbg_static_accessor_SELF_37c5d418e4bf5819: function() {
+    const ret = typeof self === "undefined" ? null : self;
+    return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+  },
+  __wbg_static_accessor_WINDOW_5de37043a91a9c40: function() {
+    const ret = typeof window === "undefined" ? null : window;
+    return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
+  },
+  __wbg_subarray_aa9065fa9dc5df96: function(arg0: any, arg1: number, arg2: number) {
+    return arg0.subarray(arg1 >>> 0, arg2 >>> 0);
+  },
+  __wbg_versions_c71aa1626a93e0a1: function(arg0: any) {
+    return arg0.versions;
+  },
+  __wbindgen_bigint_from_u64: function(arg0: bigint) {
+    return BigInt.asUintN(64, arg0);
+  },
+  __wbindgen_init_externref_table: function() {
+    const table = wasm.__wbindgen_export_2;
+    const offset = table.grow(4);
+    table.set(0, undefined);
+    table.set(offset + 0, undefined);
+    table.set(offset + 1, null);
+    table.set(offset + 2, true);
+    table.set(offset + 3, false);
+  },
+  __wbindgen_is_function: function(arg0: unknown) {
+    return typeof arg0 === "function";
+  },
+  __wbindgen_is_object: function(arg0: unknown) {
+    return typeof arg0 === "object" && arg0 !== null;
+  },
+  __wbindgen_is_string: function(arg0: unknown) {
+    return typeof arg0 === "string";
+  },
+  __wbindgen_is_undefined: function(arg0: unknown) {
+    return arg0 === undefined;
+  },
+  __wbindgen_memory: function() {
+    return wasm.memory;
+  },
+  __wbindgen_string_new: function(arg0: number, arg1: number) {
+    return getStringFromWasm0(arg0, arg1);
+  },
+  __wbindgen_throw: function(arg0: number, arg1: number) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
+  },
 };
 
 const defaultClvmRsWasmPath = (() => {
@@ -469,7 +471,7 @@ export async function initializeClvmWasm(option?: TInitOption) {
     const path = require.resolve("clvm_wasm/clvm_wasm_bg.wasm");
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const bytes = require("fs").readFileSync(path);
-    
+
     const wasmModule = new WebAssembly.Module(bytes);
     const wasmInstance = new WebAssembly.Instance(wasmModule, imports);
     wasm = wasmInstance.exports as ClvmWasmExports;
@@ -484,4 +486,6 @@ export async function initializeClvmWasm(option?: TInitOption) {
     const wasmInstance = await WebAssembly.instantiateStreaming(fetcher, imports);
     wasm = wasmInstance.instance.exports as ClvmWasmExports;
   }
+  cachedUint8ArrayMemory0 = null;
+  wasm.__wbindgen_start();
 }


### PR DESCRIPTION
## Summary

Upgrades the bundled `clvm_wasm` from 0.7.0 (mid-2023 era) to **0.16.2**, the newest wasm build published from [clvm_rs](https://github.com/Chia-Network/clvm_rs) — about two years of runtime updates for the `run_chia_program`/`run_clvm` backend.

## What changed

- **`src/__clvm_wasm__.ts` regenerated** for the new wasm-bindgen ABI: externref table (`__wbindgen_export_2`, `__externref_table_alloc/dealloc`) replaces the JS object heap, multivalue returns replace the stack-pointer/retptr protocol, and `initializeClvmWasm()` now calls `__wbindgen_start()` after instantiation. The deferred browser/Node loader and `LazyNode.toJSON()` are preserved; the regeneration recipe comment is updated.
- **Public API unchanged**: `run_clvm`, `run_chia_program`, `serialized_length`, `node_from_bytes`, `Flag`, `LazyNode` — same signatures as before.

## Behavior change (consensus fix)

Differential testing surfaced one semantic change: **`div` with negative operands is now allowed and computes floor division**. Investigating against `clvm_rs` 0.18.0 directly (`Program.run_with_cost`) confirmed this matches **current consensus behaviour** — the old wasm's `div operator with negative operands is deprecated` error is pre-hard-fork behaviour, i.e. the bundled 0.7.0 wasm had drifted from mainnet.

Two related findings worth recording:
- Python `clvm_tools`' rust backend is silently broken with `clvm_rs` ≥ 0.17 (its `from clvm_rs import run_serialized_chia_program` hits `ImportError` and falls back to the python backend), so the Python CLI currently shows python-clvm's stale negative-div rejection rather than consensus behaviour.
- The `((X)...)` "lone atom" restriction previously believed to be newer-clvm_rs strictness is actually **python-clvm-only**; `clvm_rs` 0.18 accepts those forms, and so does this wasm — no divergence there after all.

Error strings thrown by `run_chia_program` changed format (`Raise(NodePtr(SmallAtom, 1337))` instead of `EvalErr(NodePtr(...), "clvm raise")`). They remain opaque strings and are not part of the API.

## Verification

- All 104 clvm-js tests pass; `tsc`/eslint clean; `pnpm build` succeeds.
- **clvm_tools-js regression net** against this build (local tarball override): 958/962 corpus tests pass — the 4 failures are exactly the negative-div fixtures that encode the old pre-hard-fork behaviour.
- **5000-program differential fuzz** vs Python clvm_tools: 4993 byte-identical, 1 BLS-wording-only, and the remaining **6 mismatches are all negative-div cases where this build matches clvm_rs 0.18 and the Python CLI does not**. No other behavioral change detected.

## Follow-up (separate PR in clvm_tools-js)

Bump clvm_tools-js to clvm 4.1.0 and update its 4 negative-div fixtures to the consensus outputs, noting the deliberate divergence from the (currently rust-less) Python CLI.